### PR TITLE
use e2e.go for conformance test instead

### DIFF
--- a/ansible/roles/k8s-common/defaults/main.yaml
+++ b/ansible/roles/k8s-common/defaults/main.yaml
@@ -13,7 +13,7 @@ dependency_retries: 100
 dependency_sleep: 10 # seconds
 access_scheme: https
 access_port: 443
-dns_domain: kubernetes.local
+dns_domain: cluster.local
 dns_ip: 10.100.0.10
 etcd_private_ip: 127.0.0.1
 etcd_port: 4001

--- a/hack/list-published-kube-versions.sh
+++ b/hack/list-published-kube-versions.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+for d in ci release; do
+  for l in latest stable; do
+    for v in "" -1 -1.0 -1.1 -1.2 -1.3; do
+      uri=gs://kubernetes-release/$d/$l$v.txt;
+      if gsutil -q stat $uri; then
+        echo $uri
+        gsutil cat $uri
+      fi
+    done
+  done
+done

--- a/hack/parallel-conformance.sh
+++ b/hack/parallel-conformance.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+set -x
+
+KUBE_CONFORMANCE_KUBECONFIG=${KUBE_CONFORMANCE_KUBECONFIG:-"$HOME/.kube/config"}
+KUBE_CONFORMANCE_OUTPUT_DIR=${KUBE_CONFORMANCE_OUTPUT_DIR:-"$(pwd)/output/conformance"}
+
+if [[ $# < 1 ]]; then
+  echo "Usage: $0 conformance_branch"
+  echo "Switches to given directory assumed to contain kubernetes binaries and runs all non-[Serial] [Conformance] tests (in parallel)"
+  echo "  eg: $0 ~/sandbox/kubernetes-1.2.0/"
+  exit 1
+fi
+
+KUBE_ROOT=$1
+
+pushd "${KUBE_ROOT}"
+
+echo "Conformance test run start date: $(date -u)"
+echo "Conformance test dir: ${KUBE_ROOT}"
+echo "Conformance test kubeconfig: ${KUBE_CONFORMANCE_KUBECONFIG}"
+
+function run_hack_e2e_go() {
+  # avoid provider-specific e2e setup
+  export KUBERNETES_CONFORMANCE_TEST="y"
+
+  # specify which cluster to talk to, and what credentials to use
+  export KUBECONFIG=${KUBE_CONFORMANCE_KUBECONFIG}
+
+  common_test_args=()
+  common_test_args+=("--ginkgo.v=true")
+  common_test_args+=("--ginkgo.noColor=true")
+
+  test_args=()
+  test_args+=("--ginkgo.focus=\[Conformance\]")
+  test_args+=("--ginkgo.skip=\[Serial\]")
+  test_args+=("--e2e-output-dir=${KUBE_CONFORMANCE_OUTPUT_DIR}/parallel")
+  test_args+=("--report-dir=${KUBE_CONFORMANCE_OUTPUT_DIR}/parallel")
+
+  # run everything that we can in parallel
+  GINKGO_PARALLEL=y go run hack/e2e.go --v --test --test_args="${common_test_args[*]} ${test_args[*]}" --check_version_skew=false
+}
+
+echo
+echo "Running conformance tests..."
+run_hack_e2e_go
+conformance_result=$?
+
+popd
+
+echo
+echo "Conformance test run stop date: $(date -u)"
+exit $conformance_result

--- a/hack/serial-conformance.sh
+++ b/hack/serial-conformance.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+set -x
+
+KUBE_CONFORMANCE_KUBECONFIG=${KUBE_CONFORMANCE_KUBECONFIG:-"$HOME/.kube/config"}
+KUBE_CONFORMANCE_OUTPUT_DIR=${KUBE_CONFORMANCE_OUTPUT_DIR:-"$(pwd)/output/conformance"}
+
+if [[ $# < 1 ]]; then
+  echo "Usage: $0 conformance_branch"
+  echo "Switches to given directory assumed to contain kubernetes binaries and runs all [Serial] [Conformance] tests"
+  echo "  eg: $0 ~/sandbox/kubernetes-1.2.0/"
+  exit 1
+fi
+
+KUBE_ROOT=$1
+
+pushd "${KUBE_ROOT}"
+
+echo "Conformance test run start date: $(date -u)"
+echo "Conformance test dir: ${KUBE_ROOT}"
+echo "Conformance test kubeconfig: ${KUBE_CONFORMANCE_KUBECONFIG}"
+
+function run_hack_e2e_go() {
+  # avoid provider-specific e2e setup
+  export KUBERNETES_CONFORMANCE_TEST="y"
+
+  # specify which cluster to talk to, and what credentials to use
+  export KUBECONFIG=${KUBE_CONFORMANCE_KUBECONFIG}
+
+  common_test_args=()
+  common_test_args+=("--ginkgo.v=true")
+  common_test_args+=("--ginkgo.noColor=true")
+
+  test_args=()
+  test_args+=("--ginkgo.focus=\[Serial\].*\[Conformance\]")
+  test_args+=("--e2e-output-dir=${KUBE_CONFORMANCE_OUTPUT_DIR}/serial")
+  test_args+=("--report-dir=${KUBE_CONFORMANCE_OUTPUT_DIR}/serial")
+
+  # finish up with remaining cases in serial
+  go run hack/e2e.go --v --test --test_args="${common_test_args[*]} ${test_args[*]}" --check_version_skew=false
+}
+
+echo
+echo "Running conformance tests..."
+run_hack_e2e_go
+conformance_result=$?
+
+popd
+
+echo
+echo "Conformance test run stop date: $(date -u)"
+exit $conformance_result


### PR DESCRIPTION
ok this is ready for a look, will need changes on kraken-ci-jobs to actually use the new scripts