### PR TITLE
Add dependencies to support paramiko 2.0.0

### DIFF
--- a/bin/build/Dockerfile
+++ b/bin/build/Dockerfile
@@ -6,10 +6,8 @@ ENV TERRAFORM_VERSION 0.6.14
 ENV TERRAFORM_EXECUTE_VERSION v0.0.2
 ENV TERRAFORM_COREOSBOX_VERSION v0.0.1
 ENV KUBERNETES_VERSION v1.1.3
-ENV ANSIBLE_VERSION 2.0.0.2
-ENV AWSCLI_VERSION 1.10.4
 
-# python and ansible
+# system dependencie
 RUN apt-get update \
     && apt-get install -y --force-yes \
       build-essential \
@@ -23,11 +21,12 @@ RUN apt-get update \
       libssl-dev \
       unzip \
       vim \
-    && mkdir /etc/ansible/ \
-    && pip install --upgrade cffi==1.5.0 \
-    && pip install ansible==${ANSIBLE_VERSION} \
-    && pip install awscli==${AWSCLI_VERSION} \
     && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# python dependencies
+COPY bin/build/requirements.txt /tmp/requirements.txt
+RUN pip install --upgrade --requirement /tmp/requirements.txt \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # terraform and custom providers

--- a/bin/build/Dockerfile
+++ b/bin/build/Dockerfile
@@ -12,15 +12,19 @@ ENV AWSCLI_VERSION 1.10.4
 # python and ansible
 RUN apt-get update \
     && apt-get install -y --force-yes \
+      build-essential \
       curl \
-      unzip \
       jq \
-      python-pip \
+      libffi-dev \
       python-dev \
+      python-pip \
       python-yaml \
       openssh-client \
+      libssl-dev \
+      unzip \
       vim \
     && mkdir /etc/ansible/ \
+    && pip install --upgrade cffi==1.5.0 \
     && pip install ansible==${ANSIBLE_VERSION} \
     && pip install awscli==${AWSCLI_VERSION} \
     && apt-get clean \

--- a/bin/build/requirements.txt
+++ b/bin/build/requirements.txt
@@ -1,0 +1,4 @@
+ansible==2.0.0.2
+awscli==1.10.4
+paramiko==2.0.0
+cffi==1.5.0

--- a/bin/utils.sh
+++ b/bin/utils.sh
@@ -8,6 +8,7 @@ my_dir=$(dirname "${BASH_SOURCE}")
 
 # set KRAKEN_ROOT to absolute path for use in other scripts
 readonly KRAKEN_ROOT=$(cd "${my_dir}/.."; pwd)
+KRAKEN_VERBOSE=${KRAKEN_VERBOSE:-false}
 
 function warn {
   echo -e "\033[1;33mWARNING: $1\033[0m"
@@ -28,7 +29,11 @@ function follow {
 
 function run_command {
   inf "Running:\n $1"
-  eval $1 &> /dev/null
+  if ${KRAKEN_VERBOSE}; then
+    eval $1
+  else
+    eval $1 &> /dev/null
+  fi
 }
 
 function setup_dockermachine {


### PR DESCRIPTION
It looks like our install of ansible is pulling in a newer version of
paramiko that now expects ffi-related headers to be present