### PR TITLE
[WIP] Collect logs from all nodes in a kubernetes cluster (attempt 2)

### DIFF
--- a/hack/log-dump.sh
+++ b/hack/log-dump.sh
@@ -126,14 +126,14 @@ function save_etcd_logs() {
   done
 }
 
-function save_minion_logs() {
+function save_node_logs() {
   node_names=$(awk 'sub(/\[node\]/,""){f=1} /^\[[^\]\r\n]+/{f=0} {if (f) print $1}' ${KRAKEN_CLUSTER_ANSIBLE_HOSTS})
 
   for node_name in ${node_names}; do
     node_prefix="${LOG_DIRECTORY}/${node_name}"
     mkdir -p "${node_prefix}"
 
-    echo "Dumping logs for minion ${node_name}"
+    echo "Dumping logs for node ${node_name}"
 
     save_common_logs "${node_name}" "${node_prefix}"
   done
@@ -145,7 +145,7 @@ function main() {
   save_master_logs
   save_api_server_logs
   save_etcd_logs
-  save_minion_logs
+  save_node_logs
 }
 
 main

--- a/hack/log-dump.sh
+++ b/hack/log-dump.sh
@@ -21,10 +21,6 @@ case $key in
   CLUSTER_NAME="$2"
   shift
   ;;
-  --user-prefix)
-  USER_PREFIX="$2"
-  shift
-  ;;
   --log-directory)
   LOG_DIRECTORY="$2"
   shift
@@ -37,10 +33,7 @@ shift # past argument or value
 done
 
 [[ -n "${CLUSTER_NAME-}" ]] || die "The --clustername parameter is required"
-[[ -n "${USER_PREFIX-}" ]] || die "The --user-prefix parameter is required" 
 LOG_DIRECTORY=${LOG_DIRECTORY:-"$(pwd)/_artifacts"}
-
-CLUSTER_ID="${USER_PREFIX}_${CLUSTER_NAME}"
 
 KRAKEN_ROOT=${KRAKEN_ROOT:-"$(pwd)"}
 KRAKEN_CLUSTER_DIR="${KRAKEN_ROOT}/bin/clusters/${CLUSTER_NAME}"
@@ -86,7 +79,7 @@ function save_common_logs() {
 
     save_log "${node_name}" "journalctl --output=cat -k" "${node_prefix}/kern.log"
     save_log "${node_name}" "journalctl --output=cat -u docker" "${node_prefix}/docker.log"
-    save_log "${node_name}" "sudo journalctl --output=cat -u k8s-binary-kubelet.service" "${node_prefix}/kubelet.log"
+    save_log "${node_name}" "journalctl --output=cat -u k8s-binary-kubelet.service" "${node_prefix}/kubelet.log"
     save_directory "${node_name}" "/var/log/k8s" "${node_prefix}"
 }
 

--- a/hack/log-dump.sh
+++ b/hack/log-dump.sh
@@ -1,0 +1,163 @@
+#!/bin/bash
+
+# Copies logs useful for debugging kubernetes, container, or system problems to a
+# directory of your choosing. Assumes the cluster was built using kraken.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+die () {
+    echo >&2 "$@"
+    exit 1
+}
+
+while [[ $# > 1 ]]
+do
+key="$1"
+
+case $key in
+  --clustername)
+  KRAKEN_CLUSTER_NAME="$2"
+  shift
+  ;;
+  --user-prefix)
+  USER_PREFIX="$2"
+  shift
+  ;;
+  --log-directory)
+  LOG_DIRECTORY="$2"
+  shift
+  ;;
+  *)
+    # unknown option
+  ;;
+esac
+shift # past argument or value
+done
+
+[[ -n "${KRAKEN_CLUSTER_NAME-}" ]] || die "The --clustername parameter is required"
+[[ -n "${USER_PREFIX-}" ]] || die "The --user-prefix parameter is required" 
+LOG_DIRECTORY=${LOG_DIRECTORY:-"$(pwd)/_artifacts"}
+
+KRAKEN_ROOT=${KRAKEN_ROOT:-"$(pwd)"}
+KRAKEN_CLUSTER_DIR="${KRAKEN_ROOT}/bin/clusters/${KRAKEN_CLUSTER_NAME}"
+KRAKEN_CLUSTER_SSH_CONFIG="${KRAKEN_CLUSTER_DIR}/ssh_config"
+
+SSH_CMD="ssh -F ${KRAKEN_CLUSTER_SSH_CONFIG}"
+SCP_CMD="scp -F ${KRAKEN_CLUSTER_SSH_CONFIG}"
+AWS_CMD="aws ec2"
+
+function ensure_prefix() {
+  local -r node_name="${1}"
+  node_prefix="${LOG_DIRECTORY}/${node_name}"
+  mkdir -p "${node_prefix}"
+}
+
+# Saves the output of running a given command ($2) on a given node ($1)
+# into a given local file ($3). Does not fail if the ssh command fails for any
+# reason, just prints an error to stderr.
+function save_log() {
+  local -r node_name="${1}"
+  local -r cmd="${2}"
+  local -r output_file="${3}"
+
+  if ! ${SSH_CMD} "${node_name}" "${cmd}" > "${output_file}"; then
+      echo "WARN: ${SSH_CMD} ${node_name} ${cmd} > ${output_file}" >&2
+  fi
+}
+
+# Copies a remote directory ${2} from a given node ${1} and stores it in the
+# destination directory ${3}. Does not fail if the ssh command fails for any
+# reason, just prints an error to stderr.
+function save_directory() {
+  local -r node_name="${1}"
+  local -r remote_directory="${2}"
+  local -r destination_directory="${3}"
+
+  if ! ${SCP_CMD} -r "${node_name}":"${remote_directory}" "${destination_directory}";
+ then
+    echo "WARN: ${SCP_CMD} -r ${node_name}:${remote_directory} ${destination_directory}" >&2
+  fi
+}
+
+# Retrives logs from node name ($1) and stores them in files under directory ($2).
+function save_common_logs() {
+    local -r node_name="${1}"
+    local -r node_prefix="${2}"
+
+    echo "Dumping common logs for ${node_name}"
+
+    save_log "${node_name}" "journalctl --output=cat -k" "${node_prefix}/kern.log"
+    save_log "${node_name}" "journalctl --output=cat -u docker" "${node_prefix}/docker.log"
+    save_log "${node_name}" "sudo journalctl --output=cat -u k8s-binary-kubelet.service" "${node_prefix}/kubelet.log"
+    save_directory "${node_name}" "/var/log/k8s" "${node_prefix}"
+}
+
+function save_master_logs() {
+  node_names=("master")
+
+  for node_name in ${node_names}; do
+    node_prefix="${LOG_DIRECTORY}/${node_name}"
+    mkdir -p "${node_prefix}"
+
+    echo "Dumping logs for master ${node_name}"
+
+    save_log "${node_name}" "journalctl --output=cat -u k8s-binary-controller-manager.service" "${node_prefix}/kube-controller-manager.log"
+    save_log "${node_name}" "journalctl --output=cat -u kube-scheduler.log" "${node_prefix}/kube-scheduler.log"
+    save_common_logs "${node_name}" "${node_prefix}"
+  done
+}
+
+function save_api_server_logs() {
+  node_names=("apiserver-001")
+
+  for node_name in ${node_names}; do
+    node_prefix="${LOG_DIRECTORY}/${node_name}"
+    mkdir -p "${node_prefix}"
+
+    echo "Dumping logs for apiserver ${node_name}"
+
+    save_log "${node_name}" "journalctl --output=cat -u k8s-binary-apiserver.service" "${node_prefix}/kube-apiserver.log"
+    save_common_logs "${node_name}" "${node_prefix}"
+  done
+}
+
+function save_etcd_logs() {
+  node_names=("etcd")
+
+  for node_name in ${node_names}; do
+    node_prefix="${LOG_DIRECTORY}/${node_name}"
+    mkdir -p "${node_prefix}"
+
+    echo "Dumping logs for etcd ${node_name}"
+
+    save_log "${node_name}" "journalctl --output=cat -u etcd2.service" "${node_prefix}/kube-etcd.log"
+    save_common_logs "${node_name}" "${node_prefix}"
+  done
+}
+
+function save_minion_logs() {
+  node_names=("node-001")
+
+  echo "Node Names: ${node_names[*]}"
+  for node_name in "${node_names[@]}"; do
+    node_prefix="${LOG_DIRECTORY}/${node_name}"
+    mkdir -p "${node_prefix}"
+
+    echo "Dumping logs for minion ${node_name}"
+
+    save_common_logs "${node_name}" "${node_prefix}"
+  done
+}
+
+function main() {
+  echo "Dumping all node logs to ${LOG_DIRECTORY}"
+
+  save_master_logs
+  save_api_server_logs
+  save_etcd_logs
+  save_minion_logs
+}
+
+main

--- a/terraform/aws/aws.tf
+++ b/terraform/aws/aws.tf
@@ -454,7 +454,7 @@ resource "aws_instance" "kubernetes_master" {
     Name      = "${var.aws_user_prefix}_${var.cluster_name}_master"
     ShortName = "master"
     ClusterId = "${var.aws_user_prefix}_${var.cluster_name}"
-    Role = "master"
+    Role      = "master"
   }
 }
 
@@ -658,7 +658,7 @@ resource "aws_autoscaling_group" "kubernetes_nodes" {
 
   tag {
     key                 = "Role"
-    value               = "minion"
+    value               = "node"
     propagate_at_launch = true
   }
 }

--- a/terraform/aws/aws.tf
+++ b/terraform/aws/aws.tf
@@ -307,6 +307,8 @@ resource "aws_instance" "kubernetes_etcd" {
   tags {
     Name      = "${var.aws_user_prefix}_${var.cluster_name}_etcd"
     ShortName = "etcd"
+    ClusterId = "${var.aws_user_prefix}_${var.cluster_name}"
+    Role      = "etcd"
   }
 }
 
@@ -375,6 +377,8 @@ resource "aws_instance" "kubernetes_apiserver" {
   tags {
     Name      = "${var.aws_user_prefix}_${var.cluster_name}_apiserver-${format("%03d", count.index+1)}"
     ShortName = "${format("apiserver-%03d", count.index+1)}"
+    ClusterId = "${var.aws_user_prefix}_${var.cluster_name}"
+    Role      = "apiserver"
   }
 }
 
@@ -449,6 +453,8 @@ resource "aws_instance" "kubernetes_master" {
   tags {
     Name      = "${var.aws_user_prefix}_${var.cluster_name}_master"
     ShortName = "master"
+    ClusterId = "${var.aws_user_prefix}_${var.cluster_name}"
+    Role = "master"
   }
 }
 
@@ -535,6 +541,8 @@ resource "aws_instance" "kubernetes_node_special" {
   tags {
     Name      = "${var.aws_user_prefix}_${var.cluster_name}_node-${format("%03d", count.index+1)}"
     ShortName = "${format("node-%03d", count.index+1)}"
+    ClusterId = "${var.aws_user_prefix}_${var.cluster_name}"
+    Role      = "special"
   }
 }
 
@@ -639,6 +647,18 @@ resource "aws_autoscaling_group" "kubernetes_nodes" {
   tag {
     key                 = "ShortName"
     value               = "node-autoscaled"
+    propagate_at_launch = true
+  }
+
+  tag {
+    key                 = "ClusterId"
+    value               = "${var.aws_user_prefix}_${var.cluster_name}"
+    propagate_at_launch = true
+  }
+
+  tag {
+    key                 = "Role"
+    value               = "minion"
     propagate_at_launch = true
   }
 }


### PR DESCRIPTION
There are a few obvious hacks which should be cleaned up (hence it is the hack directory). The main problem I am working around here is the fact that the kubernetes supplied log-dump.sh makes assumptions which are not true for our environment (eg that both etcd and the apiserver run on the same node). Ultimately I think we need to ditch this effort and implement a full EFK solution, but this should at least allow us to make progress on a few existing JIRAs.