### PR TITLE
Fixed api-server, controller, and scheduler containerized k8s service…

### DIFF
--- a/ansible/roles/k8s-apiserver/templates/k8s-docker-apiserver.service.jinja2
+++ b/ansible/roles/k8s-apiserver/templates/k8s-docker-apiserver.service.jinja2
@@ -23,11 +23,7 @@ ExecStart=/usr/bin/docker run \
   -v {{ kubernetes_cert_dir }}:{{ kubernetes_cert_dir }} \
   -v {{apiserver_settings.log_dir}}:{{apiserver_settings.log_dir}}
   {{hyperkube_image}} \
-    /hyperkube \
-    kubelet \
-    --cluster_dns={{dns_ip}} \
-    --cluster_domain={{dns_domain}} \
-    --config=/etc/kubernetes/manifests-override \
-    --enable_server \
-    --kubeconfig={{ apiserver_settings.kubeconfig | expanduser }} \
-    --hostname_override={{master_private_ip}}
+    /hyperkube apiserver \
+  {% for k,v in apiserver_settings.iteritems() %}
+    --{{k}}={{v}} \
+  {% endfor %}

--- a/ansible/roles/k8s-controller-manager/templates/k8s-docker-controller-manager.service.jinja2
+++ b/ansible/roles/k8s-controller-manager/templates/k8s-docker-controller-manager.service.jinja2
@@ -23,11 +23,7 @@ ExecStart=/usr/bin/docker run \
   -v {{ kubernetes_cert_dir }}:{{ kubernetes_cert_dir }} \
   -v {{controller_manager_settings.log_dir}}:{{controller_manager_settings.log_dir}} \
   {{hyperkube_image}} \
-    /hyperkube \
-    kubelet \
-    --cluster_dns={{dns_ip}} \
-    --cluster_domain={{dns_domain}} \
-    --config=/etc/kubernetes/manifests-override \
-    --enable_server \
-    --kubeconfig={{ controller_manager_settings.kubeconfig | expanduser }} \
-    --hostname_override={{master_private_ip}}
+    /hyperkube controller-manager \
+  {% for k,v in controller_manager_settings.iteritems() %}
+    --{{k}}={{v}} \
+  {% endfor %}

--- a/ansible/roles/k8s-scheduler/templates/k8s-docker-scheduler.service.jinja2
+++ b/ansible/roles/k8s-scheduler/templates/k8s-docker-scheduler.service.jinja2
@@ -23,11 +23,7 @@ ExecStart=/usr/bin/docker run \
   -v {{ kubernetes_cert_dir }}:{{ kubernetes_cert_dir }} \
   -v {{scheduler_settings.log_dir}}:{{scheduler_settings.log_dir}} \
   {{hyperkube_image}} \
-    /hyperkube \
-    kubelet \
-    --cluster_dns={{dns_ip}} \
-    --cluster_domain={{dns_domain}} \
-    --config=/etc/kubernetes/manifests-override \
-    --enable_server \
-    --kubeconfig={{ scheduler_settings.kubeconfig | expanduser }} \
-    --hostname_override={{master_private_ip}}
+    /hyperkube scheduler \
+  {% for k,v in scheduler_settings.iteritems() %}
+    --{{k}}={{v}} \
+  {% endfor %}


### PR DESCRIPTION
… files

I was looking at using the k8s containerized services and realized that hypercube for api server, scheduler, and controller-manager were all specifying kubelet instead of their respective functions.