### PR TITLE
Allow service proxy subresource uri's to pass through

### DIFF
--- a/ansible/roles/kraken-master/templates/nginx.conf.jinja2
+++ b/ansible/roles/kraken-master/templates/nginx.conf.jinja2
@@ -48,6 +48,16 @@ http {
         proxy_pass https://apiservers;
     }
 
+    location ~ /api/v1/namespaces/([^/]*)/services/([^/]*)/proxy {
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_read_timeout 1200;
+        proxy_buffering off;
+        proxy_pass https://apiservers;
+    }
+
     location /nginx_status {
         stub_status on;
         access_log off;


### PR DESCRIPTION
This should allow >= v1.2 clusters to pass the "Guestbook" conformance test