### PR TITLE
Add more kubernetes api proxy uri's

### DIFF
--- a/ansible/roles/kraken-master/defaults/main.yaml
+++ b/ansible/roles/kraken-master/defaults/main.yaml
@@ -14,3 +14,9 @@ services:
   scheduler_ip: "{{master_private_ip}}"
   etcd_ip: "{{etcd_private_ip}}"
   dns_domain: "{{dns_domain}}"
+nginx:
+  kubernetes_api_proxy_uri_regexes:
+    - "/api/v1/proxy/namespaces/([^/]+)/(pods|services)"
+    - "/api/v1/proxy/nodes"
+    - "/api/v1/namespaces/([^/]+)/(pods|services)/([^/]+)/proxy"
+    - "/api/v1/nodes/([^/]+)/proxy"

--- a/ansible/roles/kraken-master/templates/nginx.conf.jinja2
+++ b/ansible/roles/kraken-master/templates/nginx.conf.jinja2
@@ -38,7 +38,8 @@ http {
         proxy_pass https://apiservers;
     }
 
-    location /api/v1/proxy/namespaces {
+    {% for regex in nginx.kubernetes_api_proxy_uri_regexes %}
+      location ~ {{ regex }} {
         proxy_set_header Host $host;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-Real-IP $remote_addr;
@@ -46,17 +47,8 @@ http {
         proxy_read_timeout 1200;
         proxy_buffering off;
         proxy_pass https://apiservers;
-    }
-
-    location ~ /api/v1/namespaces/([^/]*)/services/([^/]*)/proxy {
-        proxy_set_header Host $host;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_read_timeout 1200;
-        proxy_buffering off;
-        proxy_pass https://apiservers;
-    }
+      }
+    {% endfor %}
 
     location /nginx_status {
         stub_status on;


### PR DESCRIPTION
Naming is hard: this is for accessing services/pods/nodes through the
apiserver as opposed to hitting the nodes directly, or using an external
load balancer