### PR TITLE
KRAK-382 Increase Sysdig Cloud Agent Allowable Start Timeout

### DIFF
--- a/ansible/roles/kraken-common/templates/sysdig-cloud-agent.service.jinja2
+++ b/ansible/roles/kraken-common/templates/sysdig-cloud-agent.service.jinja2
@@ -6,8 +6,8 @@ After=docker.service
 [Service]
 Type=simple
 Restart=on-failure
-RestartSec=10
-TimeoutStartSec=10
+RestartSec=5
+TimeoutStartSec=60
 ExecStartPre=-/usr/bin/docker kill sysdig-agent
 ExecStartPre=-/usr/bin/docker rm sysdig-agent
 ExecStartPre=/usr/bin/docker pull sysdig/agent

--- a/ansible/roles/kraken-common/templates/sysdig-cloud-agent.service.jinja2
+++ b/ansible/roles/kraken-common/templates/sysdig-cloud-agent.service.jinja2
@@ -6,8 +6,8 @@ After=docker.service
 [Service]
 Type=simple
 Restart=on-failure
-RestartSec=5
-TimeoutStartSec=5
+RestartSec=10
+TimeoutStartSec=10
 ExecStartPre=-/usr/bin/docker kill sysdig-agent
 ExecStartPre=-/usr/bin/docker rm sysdig-agent
 ExecStartPre=/usr/bin/docker pull sysdig/agent


### PR DESCRIPTION
sysdig cloud agent download it taking longer than it did before.  Increased the timeout value to allow the download to finish successfully.