### PR TITLE
fixes KRAK-399

### DIFF
--- a/bin/kraken-up.sh
+++ b/bin/kraken-up.sh
@@ -31,9 +31,9 @@ run_command "docker build -t ${KRAKEN_CONTAINER_IMAGE_NAME} -f '${KRAKEN_ROOT}/b
 
 # Copy credentials to kubernetes cluster manager.
 if [ "${KRAKEN_NATIVE_DOCKER}" = false ] ; then
-  run_command "docker-machine ssh ${KRAKEN_DOCKER_MACHINE_NAME} rm -rf ${KRAKEN_AWS_CREDENTIAL_DIRECTORY}" || true
-  run_command "docker-machine ssh ${KRAKEN_DOCKER_MACHINE_NAME} mkdir -p ${KRAKEN_AWS_CREDENTIAL_DIRECTORY}" || true
-  run_command "docker-machine ssh ${KRAKEN_DOCKER_MACHINE_NAME} chmod +x ${KRAKEN_AWS_CREDENTIAL_DIRECTORY}" || true
+  run_command "docker-machine ssh ${KRAKEN_DOCKER_MACHINE_NAME} 'rm -rf ${KRAKEN_AWS_CREDENTIAL_DIRECTORY}'" || true
+  run_command "docker-machine ssh ${KRAKEN_DOCKER_MACHINE_NAME} 'mkdir -p ${KRAKEN_AWS_CREDENTIAL_DIRECTORY}'" || true
+  run_command "docker-machine ssh ${KRAKEN_DOCKER_MACHINE_NAME} 'chmod +x ${KRAKEN_AWS_CREDENTIAL_DIRECTORY}'" || true
   run_command "docker-machine scp ${AWS_CREDENTIAL_DIRECTORY}/config ${KRAKEN_DOCKER_MACHINE_NAME}:${KRAKEN_AWS_CREDENTIAL_DIRECTORY}" || true
   run_command "docker-machine scp ${AWS_CREDENTIAL_DIRECTORY}/credentials ${KRAKEN_DOCKER_MACHINE_NAME}:${KRAKEN_AWS_CREDENTIAL_DIRECTORY}" || true
 fi


### PR DESCRIPTION
Manifests as:
```
[0m[0mtemplate_file.cluster_groupvars (local-exec): Starting wait on pipelet_kraken_pr_builder-71_node_asg autoscaling group to become healthy.
[0m[0mtemplate_file.cluster_groupvars (local-exec): Unable to locate credentials. You can configure credentials by running "aws configure".
[0m[0mtemplate_file.cluster_groupvars (local-exec): Unable to locate credentials. You can configure credentials by running "aws configure".
[0m[0mtemplate_file.cluster_groupvars (local-exec): /opt/kraken/terraform/aws/kraken_asg_helper.sh: line 138: [: 0: unary operator expected
[0m[0mtemplate_file.cluster_groupvars (local-exec): Reached  nodes in pipelet_kraken_pr_builder-71_node_asg.
[0m[0mtemplate_file.cluster_groupvars (local-exec): Unable to locate credentials. You can configure credentials by running "aws configure".
[0m[0mtemplate_file.cluster_groupvars (local-exec): Unable to locate credentials. You can configure credentials by running "aws configure".
```

Problem is in the following lines of kraken-up.sh script:

```
run_command "docker-machine ssh ${KRAKEN_DOCKER_MACHINE_NAME} rm -rf ${KRAKEN_AWS_CREDENTIAL_DIRECTORY}" || true
  run_command "docker-machine ssh ${KRAKEN_DOCKER_MACHINE_NAME} mkdir -p ${KRAKEN_AWS_CREDENTIAL_DIRECTORY}" || true
  run_command "docker-machine ssh ${KRAKEN_DOCKER_MACHINE_NAME} chmod +x ${KRAKEN_AWS_CREDENTIAL_DIRECTORY}" || true
```

The ssh commands should be quoted as follows:

```
run_command "docker-machine ssh ${KRAKEN_DOCKER_MACHINE_NAME} 'rm -rf ${KRAKEN_AWS_CREDENTIAL_DIRECTORY}'" || true
  run_command "docker-machine ssh ${KRAKEN_DOCKER_MACHINE_NAME} 'mkdir -p ${KRAKEN_AWS_CREDENTIAL_DIRECTORY}'" || true
  run_command "docker-machine ssh ${KRAKEN_DOCKER_MACHINE_NAME} 'chmod +x ${KRAKEN_AWS_CREDENTIAL_DIRECTORY}'" || true
```