### PR TITLE
monkeypatch aws provider during density

### DIFF
--- a/hack/density.sh
+++ b/hack/density.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -x
 
+my_dir=$( cd $(dirname "${BASH_SOURCE}") && pwd )
+
 KUBE_DENSITY_KUBECONFIG=${KUBE_DENSITY_KUBECONFIG:-"$HOME/.kube/config"}
 KUBE_DENSITY_OUTPUT_DIR=${KUBE_DENSITY_OUTPUT_DIR:-"$(pwd)/output/density"}
 KUBE_DENSITY_SSH_USER=${KUBE_DENSITY_SSH_USER:-"core"}
@@ -18,21 +20,26 @@ KUBE_DENSITY_PODS_PER_NODE=$2
 
 pushd "${KUBE_ROOT}"
 
+# XXX: evil monkey patch: replace "aws" with a modified "skeleton" provider,
+#      since multiple places in the code are hardcoded to assume that aws
+#      allows ssh access.  would like to pr back to allow "skeleton" to be
+#      used, but will flesh out skeleton via this monkey patch for now
+mkdir -p cluster/aws.bak
+mv cluster/aws/* cluster/aws.bak/
+cp ${my_dir}/kubernetes-skeleton-provider.sh cluster/aws/util.sh
+
 echo "Density test run start date: $(date -u)"
 echo "Density test dir: ${KUBE_ROOT}"
 echo "Density test kubeconfig: ${KUBE_DENSITY_KUBECONFIG}"
 
 function run_hack_e2e_go() {
-  # XXX: e2e-internal scripts assume KUBERNETES_PROVIDER=gce,
-  #      which assumes gcloud is present and configured; instead
-  #      set a provider that has fewer dependencies
+  # XXX: e2e-internal scripts will default to KUBERNETES_PROVIDER=gce if it's unset;
+  #      that provider assumes gcloud is present and configured; instead use the
+  #      "aws" provider that we just monkeypatched
   export KUBERNETES_PROVIDER=aws
 
   # XXX: e2e-internal scripts require USER to be set
   export USER=${USER:-$(whoami)}
-
-  # avoid provider-specific e2e setup
-  export KUBERNETES_CONFORMANCE_TEST="y"
 
   # specify which cluster to talk to, and what credentials to use
   export KUBECONFIG=${KUBE_DENSITY_KUBECONFIG}
@@ -46,22 +53,52 @@ function run_hack_e2e_go() {
   test_args+=("--e2e-output-dir=${KUBE_DENSITY_OUTPUT_DIR}")
   test_args+=("--report-dir=${KUBE_DENSITY_OUTPUT_DIR}")
 
-  export KUBE_SSH_USER=${KUBE_SSH_USER:-"${KUBE_DENSITY_SSH_USER}"}
-  # Provider specific args are currently required for SSH access. Note that
-  # https://github.com/kubernetes/kubernetes/issues/20919 suggests that we
-  # would like to fix kubernetes so that --provider is no longer necessary.
-  export AWS_SSH_KEY=${AWS_SSH_KEY:-"${KUBE_DENSITY_SSH_KEY}"}
+  # the KUBERNETES_PROVIDER env var doesn't tell e2e.test to use the monkeypatched aws provider, so use a flag
   test_args+=("--provider=aws")
+  # and yes, the aws provider requires the aws region be stuffed into an argument called gce-zone
   test_args+=("--gce-zone=us-west-2")
 
-  # finish up with remaining cases in serial
+  # assuming a valid kubectl/kubeconfig; get the uri for the kubernetes server we're pointed at
+  context=$(kubectl --kubeconfig=$KUBECONFIG config view -o jsonpath="{.current-context}")
+  cluster=$(kubectl --kubeconfig=$KUBECONFIG config view -o jsonpath="{.contexts[?(@.name == \"${context}\")].context.cluster}")
+  server_uri=$(kubectl --kubeconfig=$KUBECONFIG config view -o jsonpath="{.clusters[?(@.name == \"${cluster}\")].cluster.server}")
+
+  # export the environment variables the monkeypatched aws provider requires
+  export MASTER_NAME=$(echo ${server_uri} | sed -E -e 's|https?://||')
+  export KUBE_MASTER=${MASTER_NAME}
+  export KUBE_MASTER_IP=$(dig +short ${KUBE_MASTER})
+  # turn multi-line output into array
+  OLDIFS=$IFS
+  IFS=$'\n'
+  nodes=$(kubectl --kubeconfig=$KUBECONFIG get nodes --no-headers | awk '{print $1}')
+  IFS=$OLDIFS
+  # since these are arrays they can't be exported, hence the declare -p / BASH_ENV trick
+  NODE_NAMES=($nodes)
+  KUBE_NODE_IP_ADDRESSES=($nodes)
+  declare -p NODE_NAMES KUBE_NODE_IP_ADDRESS > $(pwd)/.bash_arrays
+
+  # e2e.test uses this instead of SSH_USER
+  export KUBE_SSH_USER=${KUBE_DENSITY_SSH_USER}
+  # export the environment variables cluster/log-dump assumes for ssh access in the AWS case
+  export SSH_USER=${KUBE_SSH_USER}
+  export AWS_SSH_KEY=${KUBE_DENSITY_SSH_KEY}
+
+  export BASH_ENV=$(pwd)/.bash_arrays
   go run hack/e2e.go --v --test --test_args="${common_test_args[*]} ${test_args[*]}" --check_version_skew=false
+  e2e_result=$?
+  rm ${BASH_ENV} && unset BASH_ENV
+
+  return $e2e_result
 }
 
 echo
 echo "Running density test..."
 run_hack_e2e_go
 density_result=$?
+
+# XXX: undo evil monkey patch
+mv cluster/aws.bak/* cluster/aws/
+rm -rf cluster/aws.bak
 
 popd
 

--- a/hack/kubernetes-skeleton-provider.sh
+++ b/hack/kubernetes-skeleton-provider.sh
@@ -1,0 +1,145 @@
+#!/bin/bash
+
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script contains the helper functions that each provider hosting
+# Kubernetes must implement to use cluster/kube-*.sh scripts.
+
+set -x
+
+# Must ensure that the following ENV vars are set
+function detect-master {
+	echo "KUBE_MASTER_IP: $KUBE_MASTER_IP" 1>&2
+	echo "KUBE_MASTER: $KUBE_MASTER" 1>&2
+}
+
+# Get node names if they are not static.
+function detect-node-names {
+	echo "NODE_NAMES: [${NODE_NAMES[*]}]" 1>&2
+}
+
+# Get node IP addresses and store in KUBE_NODE_IP_ADDRESSES[]
+function detect-nodes {
+	echo "KUBE_NODE_IP_ADDRESSES: [${KUBE_NODE_IP_ADDRESSES[*]}]" 1>&2
+}
+
+# Verify prereqs on host machine
+function verify-prereqs {
+	echo "Skeleton Provider: verify-prereqs not implemented" 1>&2
+}
+
+# Validate a kubernetes cluster
+function validate-cluster {
+	# by default call the generic validate-cluster.sh script, customizable by
+	# any cluster provider if this does not fit.
+	"${KUBE_ROOT}/cluster/validate-cluster.sh"
+}
+
+# Instantiate a kubernetes cluster
+function kube-up {
+	echo "Skeleton Provider: kube-up not implemented" 1>&2
+}
+
+# Delete a kubernetes cluster
+function kube-down {
+	echo "Skeleton Provider: kube-down not implemented" 1>&2
+}
+
+# Update a kubernetes cluster
+function kube-push {
+	echo "Skeleton Provider: kube-push not implemented" 1>&2
+}
+
+# Prepare update a kubernetes component
+function prepare-push {
+	echo "Skeleton Provider: prepare-push not implemented" 1>&2
+}
+
+# Update a kubernetes master
+function push-master {
+	echo "Skeleton Provider: push-master not implemented" 1>&2
+}
+
+# Update a kubernetes node
+function push-node {
+	echo "Skeleton Provider: push-node not implemented" 1>&2
+}
+
+# Execute prior to running tests to build a release if required for env
+function test-build-release {
+	echo "Skeleton Provider: test-build-release not implemented" 1>&2
+}
+
+# Execute prior to running tests to initialize required structure
+function test-setup {
+	echo "Skeleton Provider: test-setup not implemented" 1>&2
+}
+
+# Execute after running tests to perform any required clean-up
+function test-teardown {
+	echo "Skeleton Provider: test-teardown not implemented" 1>&2
+}
+
+### mods to skeleton
+
+# do nothing
+function prepare-e2e {
+  :
+}
+
+# only needed for gce; do nothing
+function detect-project() {
+  :
+}
+
+# since we're pretending to be aws, cluster/log-dump.sh expects us
+# to implement get_ssh_hostname
+function get_ssh_hostname() {
+  local mynode="$1"
+
+  if [[ "${mynode}" == "${MASTER_NAME}" ]]; then
+    echo ${KUBE_MASTER_IP}
+  else
+    # TODO: how would this work for skeleton... need to pass mapping of
+    #       node name to ssh hostname (or ip)
+
+    if [[ "$mynode" =~ "192.168" ]]; then
+      # XXX kraken assumptions: in our bare metal setup, node names are routable ip's
+      echo $mynode
+    else
+      # XXX kraken assumptions: in aws, node names are private-ip-addresses, and we can query for their public ip's
+      aws ec2 describe-instances \
+        --output text \
+        --filters Name=private-ip-address,Values=$mynode \
+        --query Reservations[].Instances[].NetworkInterfaces[0].Association.PublicIp
+    fi
+  fi
+}
+
+# copy-pasta from aws
+function ssh-to-node {
+  local node="$1"
+  local cmd="$2"
+
+  local ip=$(get_ssh_hostname ${node})
+
+  for try in {1..5}; do
+    if ssh -oLogLevel=quiet -oConnectTimeout=30 -oStrictHostKeyChecking=no -i "${AWS_SSH_KEY}" ${SSH_USER}@${ip} "echo test > /dev/null"; then
+      break
+    fi
+    sleep 5
+  done
+  ssh -oLogLevel=quiet -oConnectTimeout=30 -oStrictHostKeyChecking=no -i "${AWS_SSH_KEY}" ${SSH_USER}@${ip} "${cmd}"
+}


### PR DESCRIPTION
only "works" for kraken aws clusters, and nuc clusters

we use a modified copy of the skeleton/util.sh script to provide just
enough info for e2e.test and cluster/log-dump.sh to be capable of ssh
access to master and nodes

cluster/log-dump will complain about being unable to copy files, but it
will exit successfully, and thus so will e2e.go

this requires an ssh config that will ignore host keys by default until
upstream kubernetes/cluster/log-dump.sh is patched, eg:

Hostname *
  StrictHostKeyChecking no