### PR TITLE
default delete-collection-workers to 16

### DIFF
--- a/ansible/roles/k8s-apiserver/defaults/main.yaml
+++ b/ansible/roles/k8s-apiserver/defaults/main.yaml
@@ -7,6 +7,8 @@ apiserver_settings:
   bind-address: 0.0.0.0
   client-ca-file: "{{ kubernetes_cert_dir }}/kube-ca.pem"
   cors-allowed-origins: .*
+  # raise delete-collection-workers from default of 1 to support 5m e2e test namespace deletion threshold
+  delete-collection-workers: 16
   etcd-servers: "http://{{etcd_private_ip}}:4001"
   # TODO: enable this once we've got a separate etcd instance
   # etcd-servers-overrides: "/events#http://{{etcd_private_ip}}:4001"


### PR DESCRIPTION
this hopefully gets density jobs of > 100 nodes to successfully terminate
their e2e test namespaces under a hardcoded 5m threshold set in
kubernetes/test/e2e/framework/framework.go

this matches the setting used by some of the kubernetes/test-infra
jenkins jobs, eg: kubernetes-gce-scalability-release-1.3