### PR TITLE
change default of DNS Hostname to true

### DIFF
--- a/terraform/aws/aws.tf
+++ b/terraform/aws/aws.tf
@@ -11,7 +11,7 @@ resource "aws_vpc" "vpc" {
   cidr_block           = "10.0.0.0/16"
   instance_tenancy     = "default"
   enable_dns_support   = true
-  enable_dns_hostnames = false
+  enable_dns_hostnames = true
 
   tags {
     Name = "${var.aws_user_prefix}_${var.cluster_name}_vpc"


### PR DESCRIPTION
This is required for two reasons:
- allows for machines to reach other using aws supplied private
dns entries
- when kubernetes is aware it is running in aws, all services will
attempt to use their private DNS entry, even if its being overriden.