### PR TITLE
Mount fix, only use public key for service account

### DIFF
--- a/ansible/roles/kraken.cluster_common/tasks/docker-wait-for-mounts.yaml
+++ b/ansible/roles/kraken.cluster_common/tasks/docker-wait-for-mounts.yaml
@@ -1,14 +1,14 @@
 - name: Generate etcd .units.docker-wait-for-mounts.part files
   template: src=docker-wait-for-mounts.part.jinja2
-            dest="{{playbook_dir}}/../generated/{{kraken_config.cluster}}/etcd.{{item.name}}.units.docker-wait-for-mounts.part"
+            dest="{{ config_base | expanduser }}/{{kraken_config.cluster}}/etcd.{{item.name}}.units.docker-wait-for-mounts.part"
   with_items: "{{kraken_config.etcd}}"
 
 - name: Generate master .units.docker-wait-for-mounts.part files
   template: src=docker-wait-for-mounts.part.jinja2
-            dest="{{playbook_dir}}/../generated/{{kraken_config.cluster}}/master.units.docker-wait-for-mounts.part"
+            dest="{{ config_base | expanduser }}/{{kraken_config.cluster}}/master.units.docker-wait-for-mounts.part"
   with_items: ["{{kraken_config.master}}"]
 
 - name: Generate node .units.docker-wait-for-mounts.part files
   template: src=docker-wait-for-mounts.part.jinja2
-            dest="{{playbook_dir}}/../generated/{{kraken_config.cluster}}/node.{{item.name}}.units.docker-wait-for-mounts.part"
+            dest="{{ config_base | expanduser }}/{{kraken_config.cluster}}/node.{{item.name}}.units.docker-wait-for-mounts.part"
   with_items: "{{kraken_config.node}}"

--- a/ansible/roles/kraken.master/kraken.master.docker/tasks/service-account-key.yaml
+++ b/ansible/roles/kraken.master/kraken.master.docker/tasks/service-account-key.yaml
@@ -11,6 +11,6 @@
 
 - name: Extract service account public key
   command: >
-    openssl rsa -in {{ config_base | expanduser }}/{{kraken_config.cluster}}/certs/service-account.pem 
-      -outform PEM -pubout -out {{ config_base | expanduser }}/{{kraken_config.cluster}}/certs/service-account-pub.pem
+    openssl rsa -in {{ config_base | expanduser }}/{{kraken_config.cluster}}/certs/service-account.pem
+      -outform PEM -pubout -out {{ config_base | expanduser }}/{{kraken_config.cluster}}/certs/service-account.pem
     creates={{ config_base | expanduser }}/{{kraken_config.cluster}}/certs/service-account-pub.pem

--- a/ansible/roles/kraken.master/kraken.master.docker/templates/service-account-secret-manifest.yaml.jinja2
+++ b/ansible/roles/kraken.master/kraken.master.docker/templates/service-account-secret-manifest.yaml.jinja2
@@ -6,4 +6,3 @@ metadata:
 type: Opaque
 data:
   service-account.pem: {{ lookup('file', '{{config_base}}/{{kraken_config.cluster}}/certs/service-account.pem' | expanduser) | b64encode }}
-  service-account-pub.pem: {{ lookup('file', '{{config_base}}/{{kraken_config.cluster}}/certs/service-account-pub.pem' | expanduser) | b64encode }}


### PR DESCRIPTION
+ Mount task has wrong file location (not updated with rest of tasks)
+ Service account only needs one key - we were providing both.  Moving to just public key.  Keeps cloud config size in check