### PR TITLE
[Issue 171] Helm: Retrieve valid version string.

### DIFF
--- a/bin/clean/gofmt-clean.sh
+++ b/bin/clean/gofmt-clean.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# Copyright © 2016 Samsung CNCT
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# from http://github.com/kubernetes/kubernetes/hack/verify-gofmt.sh
+
+# This script is really designed to use after gofmt was found to fail and you want to
+# go ahead with suggestions. Its worth while having this hear in case we want to do
+# something slightly different in the future.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+ROOT=$(dirname "${BASH_SOURCE}")/../..
+
+cd "${ROOT}"
+
+gofmt=$(which gofmt)
+if [[ ! -x "${gofmt}" ]]; then
+  echo "could not find gofmt, please verify your GOPATH"
+  exit 1
+fi
+
+source "${ROOT}/bin/common.sh"
+
+# gofmt exits with non-zero exit code if it finds a problem unrelated to
+# formatting (e.g., a file does not parse correctly). Without "|| true" this
+# would have led to no useful error message from gofmt, because the script would
+# have failed before getting to the "echo" in the block below.
+diff=$( echo `valid_go_files` | xargs ${gofmt} -s -w 2>&1) || true
+if [[ -n "${diff}" ]]; then
+  echo "${diff}"
+  exit 1
+fi

--- a/cmd/cluster_down.go
+++ b/cmd/cluster_down.go
@@ -24,7 +24,6 @@ import (
 var downStagesList string
 var downtagsList string
 
-
 // downCmd represents the down command
 var downCmd = &cobra.Command{
 	Use:           "down [path to Kraken config file]",
@@ -40,7 +39,7 @@ var downCmd = &cobra.Command{
 
 		// remove when deprecation is finalized
 		if downStagesList == "all" {
-			tagList =  downtagsList
+			tagList = downtagsList
 		} else {
 			tagList = downStagesList
 		}

--- a/cmd/cluster_up.go
+++ b/cmd/cluster_up.go
@@ -37,7 +37,7 @@ var upCmd = &cobra.Command{
 
 		// remove when deprecation is finalized
 		if upStagesList == "all" {
-			tagList =  upTagsList
+			tagList = upTagsList
 		} else {
 			tagList = upStagesList
 		}

--- a/cmd/tool_helm_test.go
+++ b/cmd/tool_helm_test.go
@@ -1,0 +1,48 @@
+package cmd
+
+import (
+	"testing"
+)
+
+func TestRemovePatchVersion(t *testing.T) {
+	var res string
+	var err error
+
+	// error cases
+	errorCases := []string{
+		"",
+		"v",
+		"v1",
+		"1.0.4",
+		"v1",
+		"v2.0.",
+		"v4.6.3.2",
+	}
+
+	for _, ec := range errorCases {
+		if res, err = removePatchVersion(ec); err == nil {
+			t.Error("For error case", ec, "was not expecting to successfully remove patch version, result was", res)
+		}
+	}
+
+	// success cases
+	successCases := []string{
+		"v1.6.7",
+		"v121.5434.1253",
+	}
+
+	expectedOutput := []string{
+		"v1.6",
+		"v121.5434",
+	}
+
+	for i, sc := range successCases {
+		res, err = removePatchVersion(sc)
+		if err != nil {
+			t.Error("For success case", sc, "was not expecting to error:", err)
+		}
+		if res != expectedOutput[i] {
+			t.Error("For success case", sc, "was expecting", expectedOutput[i], "but found", res)
+		}
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**: Fixes issues with using helm. Currently version string being pass has patch version, this is a bug addressed here. I have added tests to make sure this code works as it should, and have added an additional script to allow gfmt to do its thing.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #171 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```NONE
```
