### PR TITLE
[UI/UX] change spinner to avoid confusion about completion status

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -45,7 +45,7 @@ var KrakenlibTag string
 var ClusterConfigPath string
 
 // progress spinner
-var terminalSpinner = spinner.New(spinner.CharSets[35], 200*time.Millisecond)
+var terminalSpinner = spinner.New(spinner.CharSets[7], 200*time.Millisecond)
 
 // init the Krakenlib config viper instance
 var clusterConfig = viper.New()


### PR DESCRIPTION
**What this PR does / why we need it**:
Suggest to change out spinner as current one gives the impression that it will terminate when reaching the end, false impression of progression. Spinning does NOT give this perception and so less likely to cause confusion.

character set 7 chosen, minor change.
see https://github.com/briandowns/spinner

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Spinner changed to avoid impression of completion status
```
