### PR TITLE
[Issue 184 ] Fail fast when config file isnt defined

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,9 @@ COMMIT     := $(shell git rev-parse HEAD)
 REL_BRANCH := "$$(git rev-parse --abbrev-ref HEAD)"
 GOOS       ?= darwin
 GOARCH     ?= amd64
-
-LDFLAGS   := -X github.com/samsung-cnct/kraken/cmd.KrakenMajorMinorPatch=$(VERSION) \
-             -X github.com/samsung-cnct/kraken/cmd.KrakenType=$(TYPE) \
-             -X github.com/samsung-cnct/kraken/cmd.KrakenGitCommit=$(COMMIT) \
+LDFLAGS    := -X github.com/samsung-cnct/kraken/cmd.KrakenMajorMinorPatch=$(VERSION) \
+              -X github.com/samsung-cnct/kraken/cmd.KrakenType=$(TYPE) \
+              -X github.com/samsung-cnct/kraken/cmd.KrakenGitCommit=$(COMMIT) \
 
 build: LDFLAGS += -X github.com/samsung-cnct/kraken/cmd.KrakenlibTag=$(KLIB_VER)
 build:

--- a/cmd/cluster.go
+++ b/cmd/cluster.go
@@ -43,7 +43,7 @@ func init() {
 		"config",
 		"c",
 		os.ExpandEnv("$HOME/.kraken/config.yaml"),
-		"Path to the kraken cluster config")
+		"required path to the kraken cluster config")
 	clusterCmd.PersistentFlags().BoolVarP(
 		&configForced,
 		"force",

--- a/cmd/cluster_down.go
+++ b/cmd/cluster_down.go
@@ -28,13 +28,20 @@ var downtagsList string
 var downCmd = &cobra.Command{
 	Use:           "down [path to Kraken config file]",
 	Short:         "destroy a Kraken cluster",
-	SilenceErrors: true,
-	SilenceUsage:  true,
 	Long:          `Destroys a Kraken cluster described in the specified configuration yaml`,
+	SilenceErrors: true,
+	SilenceUsage:  false,
 	PreRunE:       preRunGetClusterConfig,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
-		spinnerPrefix := fmt.Sprintf("Bringing down cluster '%s' ", getFirstClusterName())
+		clusterName := getFirstClusterName()
+
+		// we do not support any additional arguments, we error out then if there are.
+		if len(args) > 0 {
+			return fmt.Errorf("Unexpected argument(s) passed %v", args)
+		}
+
+		spinnerPrefix := fmt.Sprintf("Bringing down cluster '%s' ", clusterName)
 		var tagList string
 
 		// remove when deprecation is finalized
@@ -56,7 +63,7 @@ var downCmd = &cobra.Command{
 		}
 
 		onFailure := func(out []byte) {
-			fmt.Printf("ERROR bringing down %s \n", getFirstClusterName())
+			fmt.Printf("ERROR bringing down %s \n", clusterName)
 			fmt.Printf("%s", out)
 			clusterHelpError(HelpTypeDestroyed, ClusterConfigPath)
 		}

--- a/cmd/cluster_helper.go
+++ b/cmd/cluster_helper.go
@@ -24,8 +24,8 @@ const (
 )
 
 func preRunGetClusterConfig(cmd *cobra.Command, args []string) error {
-	if !cmd.Flag("config").Changed {
-		fmt.Printf("config file path not given, using default config file location (%s)\n", ClusterConfigPath)
+	if ClusterConfigPath == "" {
+		return fmt.Errorf("please pass a valid kraken config file.")
 	}
 
 	_, err := os.Stat(ClusterConfigPath)

--- a/cmd/cluster_info.go
+++ b/cmd/cluster_info.go
@@ -38,6 +38,7 @@ var infoCmd = &cobra.Command{
 
 		clusterHelp(HelpTypeCreated, ClusterConfigPath)
 		ExitCode = 0
+		return nil
 	},
 }
 

--- a/cmd/cluster_info.go
+++ b/cmd/cluster_info.go
@@ -15,6 +15,8 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 )
 
@@ -23,11 +25,17 @@ var infoCmd = &cobra.Command{
 	Use:           "info",
 	Short:         "Print out cluster state information",
 	SilenceErrors: true,
-	SilenceUsage:  true,
+	SilenceUsage:  false,
 	Long: `Output some basic information on the current
 	cluster state configured by the specified Krakenlib yaml`,
 	PreRunE: preRunGetClusterConfig,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
+
+		// we do not support any additional arguments, we error out then if there are.
+		if len(args) > 0 {
+			return fmt.Errorf("Unexpected argument(s) passed %v", args)
+		}
+
 		clusterHelp(HelpTypeCreated, ClusterConfigPath)
 		ExitCode = 0
 	},

--- a/cmd/cluster_up.go
+++ b/cmd/cluster_up.go
@@ -29,10 +29,19 @@ var upCmd = &cobra.Command{
 	Use:     "up [path to Kraken config file]",
 	Short:   "Creates a Kraken cluster",
 	Long:    `Creates a Kraken cluster described in the specified configuration yaml`,
+	SilenceErrors: true,
+	SilenceUsage:  false,
 	PreRunE: preRunGetClusterConfig,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
-		spinnerPrefix := fmt.Sprintf("Bringing up cluster '%s' ", getFirstClusterName())
+		clusterName := getFirstClusterName()
+
+		// we do not support any additional arguments, we error out then if there are.
+		if len(args) > 0 {
+			return fmt.Errorf("Unexpected argument(s) passed %v", args)
+		}
+
+		spinnerPrefix := fmt.Sprintf("Bringing up cluster '%s' ", clusterName)
 		var tagList string
 
 		// remove when deprecation is finalized
@@ -54,7 +63,7 @@ var upCmd = &cobra.Command{
 		}
 
 		onFailure := func(out []byte) {
-			fmt.Printf("ERROR bringing up %s \n", getFirstClusterName())
+			fmt.Printf("ERROR bringing up %s \n", clusterName)
 			fmt.Printf("%s", out)
 			clusterHelpError(HelpTypeCreated, ClusterConfigPath)
 		}

--- a/cmd/tool.go
+++ b/cmd/tool.go
@@ -42,5 +42,5 @@ func init() {
 		"config",
 		"c",
 		os.ExpandEnv("$HOME/.kraken/config.yaml"),
-		"Path to the kraken cluster config")
+		"required path to the kraken cluster config")
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently we fall back to the default kraken location for a generated config file. This may be ok in this one case only but leads and can lead to confusion. I would rather have the app fail if the config file isnt defined, or if there is an issue with the one defined than falling back into some sort of default

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #184

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
No longer falling back to default config.yaml file.
```
