### PR TITLE
[Issue 28] go fetching gox is now part of the compile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ build:
 	@env GOOS=$(GOOS) GOARCH=$(GOARCH) go build -ldflags '$(LDFLAGS)'
 
 compile: LDFLAGS += -X github.com/samsung-cnct/kraken/cmd.KrakenlibTag=$(KLIB_VER)
-compile:
+compile: deps
 	@rm -rf build/
 	@gox -ldflags '$(LDFLAGS)' \
          -osarch="linux/386" \
@@ -32,7 +32,7 @@ install:
 	@go install -ldflags '$(LDLFLAGS)'
 
 deps:
-	go get github.com/mitchellh/gox
+	@go get github.com/mitchellh/gox
 
 dist: compile
 	$(eval FILES := $(shell ls build))


### PR DESCRIPTION
**What this PR does / why we need it**: On new machines without gox, compile, and releasing will fail without calling the `make deps` being called. Here we eliminate the need for this by making it part of the compile process anyway.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #28

**Special notes for your reviewer**: 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
