### PR TITLE
[Issue 192] removed gox dep.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,7 +32,7 @@ podTemplate(label: 'kraken',
                 withEnv(["GOPATH=${WORKSPACE}/go/"]) {
                     stage('Test: Unit') {
                         kubesh "cd go/src/github.com/samsung-cnct/kraken/ && gosimple ."
-                        kubesh "cd go/src/github.com/samsung-cnct/kraken/ && make deps && make build KLIB_VER=${k2_image_tag}"
+                        kubesh "cd go/src/github.com/samsung-cnct/kraken/ && make build KLIB_VER=${k2_image_tag}"
                         kubesh "cd go/src/github.com/samsung-cnct/kraken/ && go vet"
                         kubesh "cd go/src/github.com/samsung-cnct/kraken/cmd && go test -v"
                     }

--- a/Makefile
+++ b/Makefile
@@ -1,42 +1,46 @@
-NAME       := kraken
-VERSION    := 1.0.8
-KLIB_VER   ?= latest
-TYPE       := stable
-COMMIT     := $(shell git rev-parse HEAD)
-REL_BRANCH := "$$(git rev-parse --abbrev-ref HEAD)"
-GOOS       ?= darwin
-GOARCH     ?= amd64
-LDFLAGS    := -X github.com/samsung-cnct/kraken/cmd.KrakenMajorMinorPatch=$(VERSION) \
-              -X github.com/samsung-cnct/kraken/cmd.KrakenType=$(TYPE) \
-              -X github.com/samsung-cnct/kraken/cmd.KrakenGitCommit=$(COMMIT) \
+NAME         := kraken
+VERSION      := 1.0.8
+KLIB_VER     ?= latest
+TYPE         := stable
+COMMIT       := $(shell git rev-parse HEAD)
+REL_BRANCH   := "$$(git rev-parse --abbrev-ref HEAD)"
+GOOS         ?= darwin
+GOARCH       ?= amd64
+LDFLAGS      := -X github.com/samsung-cnct/kraken/cmd.KrakenMajorMinorPatch=$(VERSION) \
+                -X github.com/samsung-cnct/kraken/cmd.KrakenType=$(TYPE) \
+                -X github.com/samsung-cnct/kraken/cmd.KrakenGitCommit=$(COMMIT) \
+
 
 build: LDFLAGS += -X github.com/samsung-cnct/kraken/cmd.KrakenlibTag=$(KLIB_VER)
 build:
 	@env GOOS=$(GOOS) GOARCH=$(GOARCH) go build -ldflags '$(LDFLAGS)'
 
 compile: LDFLAGS += -X github.com/samsung-cnct/kraken/cmd.KrakenlibTag=$(KLIB_VER)
-compile: deps
-	@rm -rf build/
-	@gox -ldflags '$(LDFLAGS)' \
-         -osarch="linux/386" \
-         -osarch="linux/amd64" \
-         -osarch="darwin/amd64" \
-         -output "build/{{.Dir}}_$(VERSION)_{{.OS}}_{{.Arch}}/$(NAME)" \
-	     ./...
+compile: clean_dist linux_386 linux_amd64 darwin
 
-clean:
+linux_386:
+	@env GOOS=linux GOARCH=386 go build -ldflags '$(LDFLAGS)' -o build/$(NAME)_$(VERSION)_linux_386/$(NAME)
+
+linux_amd64:
+	@env GOOS=linux GOARCH=amd64 go build -ldflags '$(LDFLAGS)' -o build/$(NAME)_$(VERSION)_linux_amd64/$(NAME)
+
+darwin:
+	@env GOOS=darwin GOARCH=amd64 go build -ldflags '$(LDFLAGS)' -o build/$(NAME)_$(VERSION)_darwin_amd64/$(NAME)
+
+clean_dist:
 	@rm -rf dist/
+
+clean_build:
 	@rm -rf build/
+
+clean: clean_dist clean_build
 
 install:
 	@go install -ldflags '$(LDLFLAGS)'
 
-deps:
-	@go get github.com/mitchellh/gox
-
-dist: compile
+dist: clean_dist compile
 	$(eval FILES := $(shell ls build))
-	@rm -rf dist && mkdir dist
+	@mkdir dist
 	@for f in $(FILES); do \
 		(cd $(shell pwd)/build/$$f && tar -cvzf ../../dist/$$f.tar.gz *); \
 		(cd $(shell pwd)/dist && shasum -a 512 $$f.tar.gz > $$f.sha512); \

--- a/Makefile
+++ b/Makefile
@@ -18,12 +18,15 @@ build:
 compile: LDFLAGS += -X github.com/samsung-cnct/kraken/cmd.KrakenlibTag=$(KLIB_VER)
 compile: clean_dist linux_386 linux_amd64 darwin
 
+linux_386: LDFLAGS += -X github.com/samsung-cnct/kraken/cmd.KrakenlibTag=$(KLIB_VER)
 linux_386:
 	@env GOOS=linux GOARCH=386 go build -ldflags '$(LDFLAGS)' -o build/$(NAME)_$(VERSION)_linux_386/$(NAME)
 
+linux_amd64: LDFLAGS += -X github.com/samsung-cnct/kraken/cmd.KrakenlibTag=$(KLIB_VER)
 linux_amd64:
 	@env GOOS=linux GOARCH=amd64 go build -ldflags '$(LDFLAGS)' -o build/$(NAME)_$(VERSION)_linux_amd64/$(NAME)
 
+darwin: LDFLAGS += -X github.com/samsung-cnct/kraken/cmd.KrakenlibTag=$(KLIB_VER)
 darwin:
 	@env GOOS=darwin GOARCH=amd64 go build -ldflags '$(LDFLAGS)' -o build/$(NAME)_$(VERSION)_darwin_amd64/$(NAME)
 
@@ -57,4 +60,4 @@ release: dist
 verify:
 	./bin/verify.sh; \
 
-.PHONY: build compile install deps dist release
+.PHONY: build compile install deps dist release linux_386 linux_amd64 darwin


### PR DESCRIPTION
**What this PR does / why we need it**: Changed makefile to remove gox dep and give us a bit more control about the release process.


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #192 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
GOX is no longer necessary or required to build/compile/release.
```
