### PR TITLE
[Issue 21] error message is now correct for the case where outputLocation is not default

### DIFF
--- a/cmd/cluster_helper.go
+++ b/cmd/cluster_helper.go
@@ -171,13 +171,13 @@ func clusterHelp(help HelpType, clusterConfigFile string) {
 
 	switch help {
 	case HelpTypeCreated, HelpTypeUpdated, HelpTypeDestroyed:
-		fmt.Println("Some of the cluster state MAY be available:")
+		fmt.Println("\nSome of the cluster state MAY be available:")
 
 		// output that depends on admin.kubeconfig existing
 		kubeConfigPath := path.Join(outputLocation, clusterName, "admin.kubeconfig")
 		if _, err := os.Stat(kubeConfigPath); err == nil {
 			// kubectl
-			fmt.Println("To use kubectl: ")
+			fmt.Println("\nTo use kubectl: ")
 			fmt.Printf(" kubectl --kubeconfig=%s [kubectl commands]\n", kubeConfigPath)
 
 			if outputLocation == os.ExpandEnv("$HOME/.kraken") {
@@ -189,10 +189,15 @@ func clusterHelp(help HelpType, clusterConfigFile string) {
 			// helm
 			helmPath := path.Join(outputLocation, clusterName, ".helm")
 			if _, err := os.Stat(helmPath); err == nil {
-				fmt.Println("To use helm: ")
+				fmt.Println("\nTo use helm: ")
 				fmt.Printf(" export KUBECONFIG=%s\n", kubeConfigPath)
 				fmt.Printf(" helm [helm command] --home %s\n", helmPath)
-				fmt.Printf(" or use 'kraken tool helm --config %s [helm commands]'\n", clusterConfigFile)
+
+				if outputLocation == os.ExpandEnv("$HOME/.kraken") {
+					fmt.Printf(" or use 'kraken tool --config %s helm [helm commands]'\n", clusterConfigFile)
+				} else {
+					fmt.Printf(" or use 'kraken tool --config %s --output %s helm [helm commands]'\n", clusterConfigFile, outputLocation)
+				}
 			}
 		}
 
@@ -200,7 +205,7 @@ func clusterHelp(help HelpType, clusterConfigFile string) {
 		sshConfigPath := path.Join(outputLocation, clusterName, "ssh_config")
 		if _, err := os.Stat(sshConfigPath); err == nil {
 			// ssh tool
-			fmt.Println("To use ssh: ")
+			fmt.Println("\nTo use ssh: ")
 			fmt.Printf(" ssh <node pool name>-<number> -F %s\n", sshConfigPath)
 			// This is usage has not been implemented. See issue #49
 			//fmt.Println(" or use 'kraken tool --config ssh ssh " + clusterConfigFile + " [ssh commands]'")

--- a/cmd/cluster_helper.go
+++ b/cmd/cluster_helper.go
@@ -167,32 +167,41 @@ func clusterHelpError(help HelpType, clusterConfigFile string) {
 
 func clusterHelp(help HelpType, clusterConfigFile string) {
 	// this doesnt have to be a switch statement, but we may handle these errors different later on, so should be.
+	clusterName := getFirstClusterName()
+
 	switch help {
 	case HelpTypeCreated, HelpTypeUpdated, HelpTypeDestroyed:
 		fmt.Println("Some of the cluster state MAY be available:")
-		if _, err := os.Stat(path.Join(outputLocation, getFirstClusterName(), "admin.kubeconfig")); err == nil {
-			fmt.Println("To use kubectl: ")
-			fmt.Println(" kubectl --kubeconfig=" + path.Join(
-				outputLocation,
-				getFirstClusterName(), "admin.kubeconfig") + " [kubectl commands]")
-			fmt.Println(" or use 'kraken tool kubectl --config " + clusterConfigFile + " [kubectl commands]'")
 
-			if _, err := os.Stat(path.Join(outputLocation,
-				getFirstClusterName(), "admin.kubeconfig")); err == nil {
+		// output that depends on admin.kubeconfig existing
+		kubeConfigPath := path.Join(outputLocation, clusterName, "admin.kubeconfig")
+		if _, err := os.Stat(kubeConfigPath); err == nil {
+			// kubectl
+			fmt.Println("To use kubectl: ")
+			fmt.Printf(" kubectl --kubeconfig=%s [kubectl commands]\n", kubeConfigPath)
+
+			if outputLocation == os.ExpandEnv("$HOME/.kraken") {
+				fmt.Printf(" or use 'kraken tool --config %s kubectl [kubectl commands]'\n", clusterConfigFile)
+			} else {
+				fmt.Printf(" or use 'kraken tool --config %s --output %s kubectl [kubectl commands]'\n", clusterConfigFile, outputLocation)
+			}
+
+			// helm
+			helmPath := path.Join(outputLocation, clusterName, ".helm")
+			if _, err := os.Stat(helmPath); err == nil {
 				fmt.Println("To use helm: ")
-				fmt.Println(" export KUBECONFIG=" + path.Join(
-					outputLocation,
-					getFirstClusterName(), "admin.kubeconfig"))
-				fmt.Println(" helm [helm command] --home " + path.Join(
-					outputLocation,
-					getFirstClusterName(), ".helm"))
-				fmt.Println(" or use 'kraken tool helm --config " + clusterConfigFile + " [helm commands]'")
+				fmt.Printf(" export KUBECONFIG=%s\n", kubeConfigPath)
+				fmt.Printf(" helm [helm command] --home %s\n", helmPath)
+				fmt.Printf(" or use 'kraken tool helm --config %s [helm commands]'\n", clusterConfigFile)
 			}
 		}
 
-		if _, err := os.Stat(path.Join(outputLocation, getFirstClusterName(), "ssh_config")); err == nil {
+		// output that depends on ssh_config existing
+		sshConfigPath := path.Join(outputLocation, clusterName, "ssh_config")
+		if _, err := os.Stat(sshConfigPath); err == nil {
+			// ssh tool
 			fmt.Println("To use ssh: ")
-			fmt.Println(" ssh <node pool name>-<number> -F " + path.Join(outputLocation, getFirstClusterName(), "ssh_config"))
+			fmt.Printf(" ssh <node pool name>-<number> -F %s\n", sshConfigPath)
 			// This is usage has not been implemented. See issue #49
 			//fmt.Println(" or use 'kraken tool --config ssh ssh " + clusterConfigFile + " [ssh commands]'")
 		}

--- a/cmd/cluster_info.go
+++ b/cmd/cluster_info.go
@@ -22,12 +22,12 @@ import (
 
 // infoCmd represents the info command
 var infoCmd = &cobra.Command{
-	Use:   			"info",
-	Short: 			"Print out cluster state information",
-	Long: 			"Output some basic information on the current	cluster state configured by the specified Krakenlib yaml",
-	SilenceErrors: 	true,
-	SilenceUsage:  	false,
-	PreRunE:       	preRunGetClusterConfig,
+	Use:   "info",
+	Short: "Print out cluster state information",
+	Long: "Output some basic information on the current	cluster state configured by the specified Krakenlib yaml",
+	SilenceErrors: true,
+	SilenceUsage:  false,
+	PreRunE:       preRunGetClusterConfig,
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		// we do not support any additional arguments, we error out then if there are.


### PR DESCRIPTION
**What this PR does / why we need it**: Improved formatting for error message so that it is easier to read and change in the future. Fixed the message for running either `kraken tool kubectl` and `kraken tool helm` commands where `--output` flag is necessary if it is not set to the default location.

In addition ran `make verify` and had to address issues with `cluster info` style.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #21

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```NONE
```
