### PR TITLE
release artifact cleanup/add experimental windows binaries

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -85,7 +85,7 @@ podTemplate(label: 'kraken',
                 customContainer('golang') {
                     withEnv(["GOPATH=${WORKSPACE}/go/"]) {
                         stage('Release') {
-                            kubesh ". /home/jenkins/kraken-release-token/token && make release VERSION=${release_version} KLIB_VER=${k2_image_tag} REL_BRANCH=${release_branch}"
+                            kubesh "cd go/src/github.com/samsung-cnct/kraken/ && . /home/jenkins/kraken-release-token/token && make release VERSION=${release_version} KLIB_VER=${k2_image_tag} REL_BRANCH=${release_branch}"
                         }
                     }
                 }

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,8 @@ compile: deps
          -osarch="linux/386" \
          -osarch="linux/amd64" \
          -osarch="darwin/amd64" \
+		 -osarch="windows/386" \
+		 -osarch="windows/amd64" \
          -output "build/{{.Dir}}_$(VERSION)_{{.OS}}_{{.Arch}}/$(NAME)" \
 	     ./...
 


### PR DESCRIPTION
set the path correctly so we are only building the kraken binaries
and not strangely named other version
add some experimental windows binaries