### PR TITLE
Change the way we call golint to support multiple packages

### DIFF
--- a/bin/checks/verify-golint.sh
+++ b/bin/checks/verify-golint.sh
@@ -34,12 +34,6 @@ fi
 
 source "${ROOT}/bin/common.sh"
 
-# gofmt exits with non-zero exit code if it finds a problem unrelated to
-# formatting (e.g., a file does not parse correctly). Without "|| true" this
-# would have led to no useful error message from gofmt, because the script would
-# have failed before getting to the "echo" in the block below.
-diff=$( echo `valid_go_files` | xargs ${golint} --set_exit_status 2>&1) || true
-if [[ -n "${diff}" ]]; then
-  echo "${diff}"
-  exit 1
-fi
+for gofile in $(valid_go_files); do
+  golint --set_exit_status "$gofile"
+done


### PR DESCRIPTION
`make verify` was failing again after adding support of all golang files.

```
./bin/../bin/checks/verify-golint.sh
main.go is in package main, not cmd
```

I missed this in my previous pull request. When I added `main.go` to the golint check `make verify failed again. This happens because golint behaves differently when called it different ways.

We had been calling it like this `filelist|xargs golint`.

My testing called it like this `filelist|xargs -I {} golint {}`.

The second if like a for loop which is what I use in the PR. I believe the loop is easier to read and understand than the more involved xargs construct.

`make verify` will not work as expected for golint.

To test that `make verify` fails as it should when finding an issue add the following snippet at the bottom of `main.go` (or any other golang file. This snippet comes from the golint projects own tests.

```
// An invalid context.Context location
func y(s string, ctx context.Context) { // MATCH /context.Context should be the first parameter.*/
}
```
