### PR TITLE
Add new build and release tasks

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -94,5 +94,6 @@ release:
     - branches
   variables:
     VERSION: $CI_COMMIT_TAG
+    TYPE: stable
   script:
     - make release

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -92,5 +92,7 @@ release:
     - /v[0-9]+\.[0-9]+(\.[0-9]+[a-z]?)?/
   except:
     - branches
+  variables:
+    VERSION: $CI_COMMIT_TAG
   script:
     - make release

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,7 +17,6 @@ services:
 variables:
   DOCKER_HOST: tcp://localhost:2375
   DOCKER_DRIVER: overlay2
-  KLIB_VER: v0.12  #  need to upgrade this as appropriate for each release of kraken
 
 stages:
   - vet
@@ -95,5 +94,6 @@ release:
   variables:
     VERSION: $CI_COMMIT_TAG
     TYPE: stable
+    KLIB_VER: v0.12  #  need to upgrade this as appropriate for each release of kraken
   script:
     - make release

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -92,7 +92,5 @@ release:
     - /v[0-9]+\.[0-9]+(\.[0-9]+[a-z]?)?/
   except:
     - branches
-  variables:
-    VERSION: $CI_COMMIT_TAG
   script:
     - make release

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,5 @@
 ---
-# This pipeline requires 5 variables to be set in the CI/CD Settings
+# This pipeline requires 6 variables to be set in the CI/CD Settings
 # hint for creating the base64 encoded content: `cat .ssh/id_rsa|base64|pbcopy`
 
 # SSH_KEY - base64 encoded ssh key (think ~/.ssh/id_rsa)
@@ -7,6 +7,7 @@
 # AWS_CREDENTIALS - base64 encoded credentials file (think ~/.aws/credentials)
 # AWS_CONFIG - base64 encoded config file (think ~/.aws/config)
 # GKE_CONFIG - base64 encoded json file (think ~/.config/gcloud/someconfig.json)
+# GITHUB_TOKEN - personal access token of a robot account in github for publishing releases
 
 image: golang:latest
 
@@ -16,12 +17,14 @@ services:
 variables:
   DOCKER_HOST: tcp://localhost:2375
   DOCKER_DRIVER: overlay2
+  KLIB_VER: v0.12  #  need to upgrade this as appropriate for each release of kraken
 
 stages:
   - vet
   - prep
   - test
   - build
+  - release
 
 .gosetup: &GOSETUP
   - mkdir -p /go/src/github.com/samsung-cnct
@@ -77,3 +80,19 @@ test:gke:
     - echo "$SSH_PUBLIC_KEY" | base64 -d >.ssh/id_rsa.pub
     - echo "$GKE_CONFIG" | base64 -d >.config/gcloud/patrickRobot.json
     - hack/accpt_test gke
+
+build:
+  stage: build
+  script:
+    - make build
+
+release:
+  stage: release
+  only:
+    - /v[0-9]+\.[0-9]+(\.[0-9]+[a-z]?)?/
+  except:
+    - branches
+  variables:
+    VERSION: $CI_COMMIT_TAG
+  script:
+    - make release

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -82,11 +82,15 @@ test:gke:
 
 build:
   stage: build
+  before_script:
+    *GOSETUP
   script:
     - make build
 
 release:
   stage: release
+  before_script:
+    *GOSETUP
   only:
     - /v[0-9]+\.[0-9]+(\.[0-9]+[a-z]?)?/
   except:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,39 @@
+---
+project_name: kraken
+
+release:
+  github:
+    owner: philoserf
+    name: kraken
+  name_template: '{{.Tag}}'
+
+builds:
+  - goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+    main: .
+    ldflags: >-
+      -s -w
+      -X github.com/samsung-cnct/kraken/cmd.KrakenMajorMinorPatch=$(VERSION)
+      -X github.com/samsung-cnct/kraken/cmd.KrakenType=$(TYPE)
+      -X github.com/samsung-cnct/kraken/cmd.KrakenGitCommit=$(COMMIT)
+      -X github.com/samsung-cnct/kraken/cmd.KrakenlibTag=$(KLIB_VER)
+    binary: kraken
+
+archive:
+  format: tar.gz
+  format_overrides:
+    - goos: windows
+      format: zip
+  name_template: >-
+    {{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{
+    end }}
+  files:
+    - LICENSE*
+    - README*
+
+checksum:
+  name_template: '{{ .ProjectName }}_{{ .Version }}_checksums.txt'

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -17,10 +17,10 @@ builds:
     main: .
     ldflags: >-
       -s -w
-      -X github.com/samsung-cnct/kraken/cmd.KrakenMajorMinorPatch=$(VERSION)
-      -X github.com/samsung-cnct/kraken/cmd.KrakenType=$(TYPE)
-      -X github.com/samsung-cnct/kraken/cmd.KrakenGitCommit=$(COMMIT)
-      -X github.com/samsung-cnct/kraken/cmd.KrakenlibTag=$(KLIB_VER)
+      -X github.com/samsung-cnct/kraken/cmd.KrakenMajorMinorPatch={{.Env.VERSION}}
+      -X github.com/samsung-cnct/kraken/cmd.KrakenType={{.Env.TYPE}}
+      -X github.com/samsung-cnct/kraken/cmd.KrakenGitCommit={{.Env.COMMIT}}
+      -X github.com/samsung-cnct/kraken/cmd.KrakenlibTag={{.Env.KLIB_VER}}
     binary: kraken
 
 archive:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,7 +3,7 @@ project_name: kraken
 
 release:
   github:
-    owner: philoserf
+    owner: samsung-cnct
     name: kraken
   name_template: '{{.Tag}}'
 

--- a/Makefile
+++ b/Makefile
@@ -13,9 +13,16 @@ export COMMIT      := $(shell git rev-parse HEAD)
 bootstrap: setup ## get tools needed for local project development work
 	go get github.com/jteeuwen/go-bindata/...
 
-.PHONY: vet
-vet: ## validate code and configuration
+goreleaser := ${GOPATH}/bin/goreleaser
+$(goreleaser):
+	go get -u github.com/goreleaser/goreleaser/..
+
+gometalinter := ${GOPATH}/bin/gometalinter
+$(gometalinter):
 	go get github.com/alecthomas/gometalinter
+
+.PHONY: vet
+vet: $(gometalinter) ## validate code and configuration
 	gometalinter --install
 	gometalinter --vendored-linters \
 		--disable-all \
@@ -43,14 +50,11 @@ accpt-test-gke: ## run acceptance tests for GKE (set CI_JOB_ID for local testing
 	hack/accpt_test gke
 
 .PHONY: build # Usage: target=linux make build
-build: ## build the golang executable for the target archtectures
-	echo ${TYPE}
-	go get github.com/goreleaser/goreleaser/...
+build: $(goreleaser) ## build the golang executable for the target archtectures
 	goreleaser --rm-dist --snapshot
 
 .PHONY: release
-release: ## release the kraken with a github release
-	go get github.com/goreleaser/goreleaser/...
+release: $(goreleaser) ## release the kraken with a github release
 	VERSION=$(VERSION) TYPE=$(TYPE) $KLIB_VER=$(KLIB_VER) goreleaser --rm-dist
 
 .PHONY: local_build

--- a/Makefile
+++ b/Makefile
@@ -5,14 +5,9 @@ help: ## Display make tasks
 
 NAME        := kraken
 VERSION     := 1.2.4
-KLIB_VER    ?= latest
 TYPE        := stable
+KLIB_VER    ?= latest
 COMMIT      := $(shell git rev-parse HEAD)
-REL_BRANCH  := "$$(git rev-parse --abbrev-ref HEAD)"
-LDFLAGS     := -X github.com/samsung-cnct/kraken/cmd.KrakenMajorMinorPatch=$(VERSION) \
-			   -X github.com/samsung-cnct/kraken/cmd.KrakenType=$(TYPE) \
-			   -X github.com/samsung-cnct/kraken/cmd.KrakenGitCommit=$(COMMIT) \
-			   -X github.com/samsung-cnct/kraken/cmd.KrakenlibTag=$(KLIB_VER)
 
 .PHONY: bootstrap
 bootstrap: setup ## get tools needed for local project development work
@@ -49,11 +44,12 @@ accpt-test-gke: ## run acceptance tests for GKE (set CI_JOB_ID for local testing
 
 .PHONY: build # Usage: target=linux make build
 build: ## build the golang executable for the target archtectures
+	echo $TYPE
 	goreleaser --rm-dist --snapshot
 
 .PHONY: release
 release: ## release the kraken with a github release
-	goreleaser --rm-dist
+	VERSION=$(VERSION) TYPE=$(TYPE) $KLIB_VER=$(KLIB_VER) goreleaser --rm-dist
 
 .PHONY: local_build
 local_build: ## build for your machine

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ help: ## Display make tasks
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
 export NAME        := kraken
-export VERSION     := 1.2.4
+export VERSION     ?= 1.2.4
 export TYPE        := stable
 export KLIB_VER    ?= latest
 export COMMIT      := $(shell git rev-parse HEAD)

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ accpt-test-gke: ## run acceptance tests for GKE (set CI_JOB_ID for local testing
 
 .PHONY: build # Usage: target=linux make build
 build: ## build the golang executable for the target archtectures
-	echo $TYPE
+	echo ${TYPE}
 	go get github.com/goreleaser/goreleaser/...
 	goreleaser --rm-dist --snapshot
 

--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,11 @@
 help: ## Display make tasks
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
-NAME        := kraken
-VERSION     := 1.2.4
-TYPE        := stable
-KLIB_VER    ?= latest
-COMMIT      := $(shell git rev-parse HEAD)
+export NAME        := kraken
+export VERSION     := 1.2.4
+export TYPE        := stable
+export KLIB_VER    ?= latest
+export COMMIT      := $(shell git rev-parse HEAD)
 
 .PHONY: bootstrap
 bootstrap: setup ## get tools needed for local project development work

--- a/Makefile
+++ b/Makefile
@@ -7,11 +7,11 @@ NAME        := kraken
 VERSION     := 1.2.4
 TYPE        := stable
 KLIB_VER    ?= latest
-COMMIT      := $(shell git rev-parse HEAD)
 
 .PHONY: bootstrap
 bootstrap: setup ## get tools needed for local project development work
 	go get github.com/jteeuwen/go-bindata/...
+	go get github.com/goreleaser/goreleaser/...
 
 .PHONY: vet
 vet: ## validate code and configuration

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,6 @@ KLIB_VER    ?= latest
 .PHONY: bootstrap
 bootstrap: setup ## get tools needed for local project development work
 	go get github.com/jteeuwen/go-bindata/...
-	go get github.com/goreleaser/goreleaser/...
 
 .PHONY: vet
 vet: ## validate code and configuration
@@ -45,10 +44,12 @@ accpt-test-gke: ## run acceptance tests for GKE (set CI_JOB_ID for local testing
 .PHONY: build # Usage: target=linux make build
 build: ## build the golang executable for the target archtectures
 	echo $TYPE
+	go get github.com/goreleaser/goreleaser/...
 	goreleaser --rm-dist --snapshot
 
 .PHONY: release
 release: ## release the kraken with a github release
+	go get github.com/goreleaser/goreleaser/...
 	VERSION=$(VERSION) TYPE=$(TYPE) $KLIB_VER=$(KLIB_VER) goreleaser --rm-dist
 
 .PHONY: local_build

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ help: ## Display make tasks
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
 NAME        := kraken
-VERSION     := 1.2.3
+VERSION     := 1.2.4
 KLIB_VER    ?= latest
 TYPE        := stable
 COMMIT      := $(shell git rev-parse HEAD)
@@ -49,10 +49,11 @@ accpt-test-gke: ## run acceptance tests for GKE (set CI_JOB_ID for local testing
 
 .PHONY: build # Usage: target=linux make build
 build: ## build the golang executable for the target archtectures
-	-rm -rf build dist && mkdir build && mkdir dist
-	env CGO_ENABLED=0 GOARCH="amd64" GOOS="${target}" go build -o "./build/$(NAME)-$(VERSION)-${target}-amd64" --ldflags '$(LDFLAGS)'; \
-	env CGO_ENABLED=0 GOARCH="amd64" GOOS="${target}" tar -czf "./dist/$(NAME)-$(VERSION)-${target}-amd64.tgz" "./build/$(NAME)-$(VERSION)-${target}-amd64"; \
-	env CGO_ENABLED=0 GOARCH="amd64" GOOS="${target}" shasum -a 512 "./build/$(NAME)-$(VERSION)-${target}-amd64" > "./dist/$(NAME)-$(VERSION)-${target}-amd64.sha512"; \
+	goreleaser --rm-dist --snapshot
+
+.PHONY: release
+release: ## release the kraken with a github release
+	goreleaser --rm-dist
 
 .PHONY: local_build
 local_build: ## build for your machine
@@ -61,14 +62,6 @@ local_build: ## build for your machine
 .PHONY: clean
 clean: ## Cleanup after make compile
 	-rm -rf build dist
-
-.PHONY: release
-release: build ## Create a GitHub release
-	@latest_tag=$$(git describe --tags `git rev-list --tags --max-count=1`); \
-	comparison="$$latest_tag..HEAD"; \
-	if [ -z "$$latest_tag" ]; then comparison=""; fi; \
-	changelog=$$(git log $$comparison --oneline --no-merges --reverse); \
-	github-release samsung-cnct/$(NAME) $(VERSION) $(REL_BRANCH) "**Changelog**<br/>$$changelog" 'dist/*'; \
 
 .PHONY: regenerate-bindata
 regenerate-bindata: ## Regnerate cmd/bindata.go after changes in ./data/

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ help: ## Display make tasks
 
 export NAME        := kraken
 export VERSION     ?= 1.2.4
-export TYPE        := stable
+export TYPE        ?= alpha
 export KLIB_VER    ?= latest
 export COMMIT      := $(shell git rev-parse HEAD)
 

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ bootstrap: setup ## get tools needed for local project development work
 
 goreleaser := ${GOPATH}/bin/goreleaser
 $(goreleaser):
-	go get -u github.com/goreleaser/goreleaser/..
+	go get -u github.com/goreleaser/goreleaser/...
 
 gometalinter := ${GOPATH}/bin/gometalinter
 $(gometalinter):

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ NAME        := kraken
 VERSION     := 1.2.4
 TYPE        := stable
 KLIB_VER    ?= latest
+COMMIT      := $(shell git rev-parse HEAD)
 
 .PHONY: bootstrap
 bootstrap: setup ## get tools needed for local project development work


### PR DESCRIPTION
**What this PR does / why we need it**:

Add new build and release tasks using goreleaser: https://github.com/goreleaser/goreleaser

goreleaser builds the executables, creates TGZ and ZIP archives, generates release notes from commit messages and create the GitHub release.

It can also create a publish docker images, update homebrew definitions, create RPM, DEB, and SNAPs.

**Special notes for your reviewer**:

I bump version here in the Makefile in order to demonstrate the tool. We can edit that back before the merge.


See my fork for an example of this release: https://github.com/philoserf/kraken/releases/tag/1.2.4