### PR TITLE
Updating Documentation to match with actual code

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ When you've set the required fields, your configuration file is ready to go. The
 
 Role | # | Type
 --- | ---  | ---
-Primary etcd cluster | 5 | t2.small
-Events etcd cluster | 5 | t2.small
+Primary etcd cluster | 5 | m4.large
+Events etcd cluster | 5 | m4.large
 Master nodes | 3 | m4.large
 Cluster nodes | 10 | c4.large
 Special nodes | 2 | m4.large


### PR DESCRIPTION
The default instance for etcd nodes is m4.large and not t2.small anymore as indicated [here](https://github.com/samsung-cnct/kraken-lib/blob/8129546e82d958cfa64849ca3942a7558dc5df6b/ansible/roles/kraken.config/files/config.yaml#L186)

<!--  Thanks for sending a pull request!  Here are some tips for you:
-->

**What this PR does / why we need it**:
The documentation is out of date, keeping it up to date should be a priority.
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
