### PR TITLE
rev version of kraken-lib

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -98,6 +98,6 @@ release:
   variables:
     VERSION: $CI_COMMIT_TAG
     TYPE: stable
-    KLIB_VER: v0.12  #  need to upgrade this as appropriate for each release of kraken
+    KLIB_VER: v0.13  #  need to upgrade this as appropriate for each release of kraken
   script:
     - make release


### PR DESCRIPTION
need to update the pinned version of kraken-lib to make `kraken tools` function again.